### PR TITLE
QR Scanner Feature

### DIFF
--- a/components/button/GoToScannerButton.tsx
+++ b/components/button/GoToScannerButton.tsx
@@ -1,0 +1,42 @@
+import { TouchableOpacity, StatusBar } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { NavigationType } from "../../types/navigation";
+
+interface Props {
+  rn?: NavigationType<"DetailScreen">;
+}
+
+export default function GoToScannerButton(props: Props) {
+  // Dynamic height calculated by device's statusBarHeight + 10
+  const statusBarHeight = StatusBar.currentHeight ?? 0;
+
+  return (
+    <TouchableOpacity
+      style={{
+        width: 40,
+        height: 40,
+        top: statusBarHeight + 10,
+        right: 10,
+        backgroundColor: "#fff",
+        position: "absolute",
+        borderRadius: 100,
+        alignItems: "center",
+        justifyContent: "center",
+        shadowColor: "#000",
+        shadowOffset: {
+          width: 0,
+          height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+        elevation: 5,
+      }}
+      onPress={() => {
+        if (!props.rn) return;
+        return props.rn.navigation.navigate("ScannerScreen");
+      }}
+    >
+      <Ionicons name="camera" size={20} />
+    </TouchableOpacity>
+  );
+}

--- a/components/button/ScanQrButton.tsx
+++ b/components/button/ScanQrButton.tsx
@@ -1,0 +1,26 @@
+import { TouchableOpacity } from "react-native";
+import React from "react";
+import { Ionicons } from "@expo/vector-icons";
+
+export default function ScanQRButton() {
+  return (
+    <TouchableOpacity
+      style={{
+        paddingRight: 6,
+        borderRadius: 100,
+        alignItems: "center",
+        justifyContent: "center",
+        shadowColor: "#000",
+        shadowOffset: {
+          width: 0,
+          height: 2,
+        },
+        shadowRadius: 3.84,
+        shadowOpacity: 0.25,
+      }}
+      onPress={() => {}}
+    >
+      <Ionicons name="camera" size={24} color="black" />
+    </TouchableOpacity>
+  );
+}

--- a/components/button/ScanQrButton.tsx
+++ b/components/button/ScanQrButton.tsx
@@ -1,5 +1,4 @@
 import { TouchableOpacity } from "react-native";
-import React from "react";
 import { Ionicons } from "@expo/vector-icons";
 
 export default function ScanQRButton() {

--- a/components/button/ScanQrButton.tsx
+++ b/components/button/ScanQrButton.tsx
@@ -1,7 +1,12 @@
 import { TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { NavigationType } from "../../types/navigation";
 
-export default function ScanQRButton() {
+interface Props {
+  rn?: NavigationType<any>;
+}
+
+export default function ScanQRButton(props: Props) {
   return (
     <TouchableOpacity
       style={{
@@ -17,7 +22,10 @@ export default function ScanQRButton() {
         shadowRadius: 3.84,
         shadowOpacity: 0.25,
       }}
-      onPress={() => {}}
+      onPress={() => {
+        if (!props.rn) return;
+        return props.rn.navigation.navigate("ScannerScreen");
+      }}
     >
       <Ionicons name="camera" size={24} color="black" />
     </TouchableOpacity>

--- a/components/card/ExtensionCard.tsx
+++ b/components/card/ExtensionCard.tsx
@@ -4,10 +4,53 @@ import { NavigationType } from "../../types/navigation";
 
 interface Props {
   value: IData;
-  rn?: NavigationType<"HomeScreen">;
+  compact?: boolean;
+  rn?: NavigationType<any>;
 }
 
 export default function ExtensionCard(props: Props) {
+  if (props.compact) {
+    return (
+      <Pressable
+        android_ripple={{ color: "#666" }}
+        onPress={() => {
+          if (!props.rn) return;
+          return props.rn.navigation.replace("DetailScreen", props.value);
+        }}
+      >
+        <View className="bg-white h-[170px] rounded-xl shadow-2xl">
+          {props.value.image_url ? (
+            <View className="h-full w-full">
+              <Image
+                className="w-full h-full rounded-xl"
+                source={{
+                  uri: props.value.image_url,
+                }}
+              />
+            </View>
+          ) : undefined}
+
+          <View className="px-4 py-4 absolute bg-[#00000099] w-full h-full rounded-xl">
+            {/* ID */}
+            <Text className="font-bold">ID: {props.value.id}</Text>
+
+            {/* TITLE */}
+            <Text className="font-bold text-lg" numberOfLines={2}>
+              {props.value.title}
+            </Text>
+
+            {/* OPTIONAL DESCRIPTION */}
+            {props.value.description ? (
+              <Text className="text-justify mt-2" numberOfLines={3}>
+                {props.value.description}
+              </Text>
+            ) : undefined}
+          </View>
+        </View>
+      </Pressable>
+    );
+  }
+
   return (
     <Pressable
       android_ripple={{ color: "#666" }}

--- a/components/card/ExtensionCard.tsx
+++ b/components/card/ExtensionCard.tsx
@@ -32,16 +32,19 @@ export default function ExtensionCard(props: Props) {
 
           <View className="px-4 py-4 absolute bg-[#00000099] w-full h-full rounded-xl">
             {/* ID */}
-            <Text className="font-bold">ID: {props.value.id}</Text>
+            <Text className="font-bold text-white">ID: {props.value.id}</Text>
 
             {/* TITLE */}
-            <Text className="font-bold text-lg" numberOfLines={2}>
+            <Text className="font-bold text-lg text-white" numberOfLines={2}>
               {props.value.title}
             </Text>
 
             {/* OPTIONAL DESCRIPTION */}
             {props.value.description ? (
-              <Text className="text-justify mt-2" numberOfLines={3}>
+              <Text
+                className="text-justify mt-2 text-slate-200"
+                numberOfLines={3}
+              >
                 {props.value.description}
               </Text>
             ) : undefined}

--- a/components/header/HomeHeader.tsx
+++ b/components/header/HomeHeader.tsx
@@ -49,6 +49,7 @@ export default function HomeHeader(props: Props) {
           onChangeText={props.onChangeText}
           onSubmitEditing={props.onSubmitEditing}
           isLoading={props.isLoading}
+          rn={props.rn}
         />
       </View>
     </View>

--- a/components/input/SearchInput.tsx
+++ b/components/input/SearchInput.tsx
@@ -1,5 +1,6 @@
 import { View, TextInput, ActivityIndicator } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import ScanQRButton from "../button/ScanQrButton";
 
 interface Props {
   onChangeText: (text: string) => void;
@@ -27,6 +28,9 @@ export default function SearchInput(props: Props) {
         onChangeText={props.onChangeText}
         onSubmitEditing={props.onSubmitEditing}
       />
+
+      {/* SCAN QR CODE BUTTON */}
+      <ScanQRButton />
     </View>
   );
 }

--- a/components/input/SearchInput.tsx
+++ b/components/input/SearchInput.tsx
@@ -1,11 +1,13 @@
 import { View, TextInput, ActivityIndicator } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import ScanQRButton from "../button/ScanQrButton";
+import { NavigationType } from "../../types/navigation";
 
 interface Props {
   onChangeText: (text: string) => void;
   onSubmitEditing: () => void;
   isLoading?: boolean;
+  rn?: NavigationType<"HomeScreen">;
 }
 
 export default function SearchInput(props: Props) {
@@ -30,7 +32,7 @@ export default function SearchInput(props: Props) {
       />
 
       {/* SCAN QR CODE BUTTON */}
-      <ScanQRButton />
+      <ScanQRButton rn={props.rn} />
     </View>
   );
 }

--- a/components/miscs/DeniedCamera.tsx
+++ b/components/miscs/DeniedCamera.tsx
@@ -1,0 +1,30 @@
+import { View, Text, TouchableOpacity, Linking } from "react-native";
+import { Feather } from "@expo/vector-icons";
+
+export default function DeniedCamera() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <View className="flex flex-row px-12 items-center gap-4">
+        <View>
+          <Feather name="camera-off" size={24} color="black" />
+        </View>
+
+        <View>
+          <Text>
+            Camera permission has been denied, please allow to use the scanner.
+          </Text>
+
+          <TouchableOpacity
+            onPress={() => {
+              Linking.openSettings();
+            }}
+          >
+            <View className="py-1 flex flex-row gap-2">
+              <Text className="underline">Open settings</Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/components/miscs/RequestingCamera.tsx
+++ b/components/miscs/RequestingCamera.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function RequestingCamera() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Requesting camera permission...</Text>
+    </View>
+  );
+}

--- a/components/skeleton/ExtCardSkeleton.tsx
+++ b/components/skeleton/ExtCardSkeleton.tsx
@@ -3,6 +3,8 @@ import { Placeholder, PlaceholderLine, Fade } from "rn-placeholder";
 import NotFoundInfo from "../miscs/NotFoundInfo";
 
 interface Props {
+  count: number;
+  compact?: boolean;
   isNotFound?: boolean;
 }
 
@@ -11,41 +13,27 @@ export default function ExtCardSkeleton(props: Props) {
 
   return (
     <View>
-      <View className="bg-white mx-2 my-4 rounded-xl shadow-2xl">
-        <Placeholder Animation={Fade}>
-          <PlaceholderLine
-            height={250}
-            noMargin={true}
-            className="rounded-none rounded-t-xl mb-2"
-          />
+      {[...new Array(props.count)].map((_v, i) => (
+        <View key={i} className="bg-white mx-2 my-4 rounded-xl shadow-2xl">
+          <Placeholder Animation={Fade}>
+            {!props.compact ? (
+              <PlaceholderLine
+                height={250}
+                noMargin={true}
+                className="rounded-none rounded-t-xl mb-2"
+              />
+            ) : undefined}
 
-          <View className="p-4">
-            <PlaceholderLine width={20} height={15} />
-            <PlaceholderLine width={80} height={20} />
-            <PlaceholderLine />
-            <PlaceholderLine width={70} />
-            <PlaceholderLine width={60} />
-          </View>
-        </Placeholder>
-      </View>
-
-      <View className="bg-white mx-2 my-4 rounded-xl shadow-2xl">
-        <Placeholder Animation={Fade}>
-          <PlaceholderLine
-            height={250}
-            noMargin={true}
-            className="rounded-none rounded-t-xl mb-2"
-          />
-
-          <View className="p-4">
-            <PlaceholderLine width={20} height={15} />
-            <PlaceholderLine width={80} height={20} />
-            <PlaceholderLine />
-            <PlaceholderLine width={70} />
-            <PlaceholderLine width={60} />
-          </View>
-        </Placeholder>
-      </View>
+            <View className="p-4">
+              <PlaceholderLine width={20} height={15} />
+              <PlaceholderLine width={80} height={20} />
+              <PlaceholderLine />
+              <PlaceholderLine width={70} />
+              <PlaceholderLine width={60} />
+            </View>
+          </Placeholder>
+        </View>
+      ))}
     </View>
   );
 }

--- a/libs/fetchData.ts
+++ b/libs/fetchData.ts
@@ -19,6 +19,26 @@ export async function fetchAllData(props: IFetchData) {
   }
 }
 
+interface IFetchSpecificData {
+  id: number;
+  setData: Dispatch<SetStateAction<IData | undefined>>;
+}
+
+export async function fetchSpecificData(props: IFetchSpecificData) {
+  if (!props.setData) return;
+
+  try {
+    // Fetch data from the server.
+    // Whenever data is available,
+    // push them to the defined state.
+    const req = await fetch(`${C_URL.BACKEND_URL}/ext/${props.id}`);
+    const res = await req.json();
+    props.setData(res);
+  } catch (error: any) {
+    console.error(error.message);
+  }
+}
+
 interface IFetchSpecific extends IFetchData {
   searchText: string;
   setNotFound: Dispatch<SetStateAction<boolean>>;

--- a/libs/isNumeric.ts
+++ b/libs/isNumeric.ts
@@ -1,0 +1,3 @@
+export const isNumeric = (num: any) =>
+  (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) &&
+  !isNaN(num as number);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@react-navigation/native": "^6.0.11",
     "@react-navigation/native-stack": "^6.7.0",
     "expo": "~46.0.7",
+    "expo-barcode-scanner": "~11.4.0",
     "expo-build-properties": "~0.3.0",
     "expo-linking": "~3.2.2",
     "expo-status-bar": "~1.4.0",

--- a/screens/DetailScreen.tsx
+++ b/screens/DetailScreen.tsx
@@ -11,6 +11,7 @@ import { NavigationType } from "../types/navigation";
 import ImageView from "react-native-image-viewing";
 import BackButton from "../components/button/BackButton";
 import { IData } from "../constants/data";
+import GoToScannerButton from "../components/button/GoToScannerButton";
 
 export default function DetailScreen(props: NavigationType<"DetailScreen">) {
   // Data passed from parent component
@@ -57,6 +58,9 @@ export default function DetailScreen(props: NavigationType<"DetailScreen">) {
 
           {/* BACK NAVIGATION BUTTON */}
           <BackButton rn={props} />
+
+          {/* GO TO SCANNER BUTTON */}
+          <GoToScannerButton rn={props} />
         </View>
 
         <View className="bg-white px-4 py-6 rounded-b-2xl shadow-2xl">

--- a/screens/DetailScreen.tsx
+++ b/screens/DetailScreen.tsx
@@ -23,7 +23,7 @@ export default function DetailScreen(props: NavigationType<"DetailScreen">) {
   return (
     <ScrollView className="flex-1">
       <StatusBar
-        barStyle="dark-content"
+        barStyle="light-content"
         animated={true}
         translucent={true}
         backgroundColor="transparent"

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -76,7 +76,9 @@ export default function HomeScreen(props: NavigationType<"HomeScreen">) {
                 isLoading={loading}
               />
             }
-            ListEmptyComponent={<ExtCardSkeleton isNotFound={notFound} />}
+            ListEmptyComponent={
+              <ExtCardSkeleton count={2} isNotFound={notFound} />
+            }
           />
         </View>
 

--- a/screens/ScannerScreen.tsx
+++ b/screens/ScannerScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function ScannerScreen() {
+  return (
+    <View>
+      <Text>ScannerScreen</Text>
+    </View>
+  );
+}

--- a/screens/ScannerScreen.tsx
+++ b/screens/ScannerScreen.tsx
@@ -1,9 +1,126 @@
-import { View, Text } from "react-native";
+import ExtensionCard from "../components/card/ExtensionCard";
+import DeniedCamera from "../components/miscs/DeniedCamera";
+import RequestingCamera from "../components/miscs/RequestingCamera";
+import ExtCardSkeleton from "../components/skeleton/ExtCardSkeleton";
+import { BarCodeEvent, BarCodeScanner } from "expo-barcode-scanner";
+import { useEffect, useState } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { IData } from "../constants/data";
+import { fetchSpecificData } from "../libs/fetchData";
+import { isNumeric } from "../libs/isNumeric";
+import { Ionicons } from "@expo/vector-icons";
+import { NavigationType } from "../types/navigation";
 
-export default function ScannerScreen() {
+export default function ScannerScreen(props: NavigationType<"ScannerScreen">) {
+  // state to keep the camera permission
+  const [permission, setPermission] = useState<boolean | null>(null);
+
+  async function checkPermission() {
+    // get the permission from the device's settings
+    const data = await BarCodeScanner.requestPermissionsAsync();
+    // set to true or false based on "granted" status
+    setPermission(data.status === "granted");
+  }
+
+  useEffect(() => {
+    // check permission everytime component mounted
+    checkPermission();
+  }, []);
+
+  // State to store backend request data
+  const [data, setData] = useState<IData | undefined>();
+  const [result, setResult] = useState<string>();
+
+  // state for loading when fetching from server
+  const [loading, setLoading] = useState<boolean>(false);
+
+  async function handleSpecificFetch() {
+    // if there is no result or the result
+    // is not a numerical, return nothing.
+    if (!result || !isNumeric(result)) return;
+
+    setLoading(true);
+
+    // fetchSpecificData from the server
+    await fetchSpecificData({
+      id: parseInt(result),
+      setData: setData,
+    });
+
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    handleSpecificFetch();
+  }, [result]);
+
+  // if the permission is not yet granted,
+  // show the placeholder component.
+  // This component is only used for placeholder when
+  // permission dialog showed to the user.
+  if (permission === null) {
+    return <RequestingCamera />;
+  }
+
+  // if the user is either rejected or denied entirely,
+  // show the DeniedCamera component to show user the permission
+  // has been rejected/denied.
+  if (permission === false) {
+    return <DeniedCamera />;
+  }
+
+  function handleBarcodeScanner(scan: BarCodeEvent) {
+    // set the result from barcode scanner
+    if (scan.data) {
+      setResult(scan.data);
+    }
+  }
+
   return (
-    <View>
-      <Text>ScannerScreen</Text>
+    <View className="flex-1 px-2 py-4">
+      {/* BARCODE SCANNER */}
+      <View className="h-[500px] w-full items-center overflow-hidden rounded-2xl shadow-xl">
+        <BarCodeScanner
+          onBarCodeScanned={data ? undefined : handleBarcodeScanner}
+          style={{ height: 1000, width: 1000, borderRadius: 30 }}
+        />
+      </View>
+
+      {/* BARCODE SCANNER HELPER TEXT */}
+      <View className="py-2 items-center">
+        <Text className="text-slate-400">Scan the QR code</Text>
+      </View>
+
+      {/* SKELETON */}
+      {loading ? <ExtCardSkeleton count={1} compact={true} /> : undefined}
+
+      {/* FOUND DATA TITLE AND RESET BUTTON */}
+      {data && !loading ? (
+        <View className="flex flex-row justify-between px-2 my-4">
+          <Text className="text-slate-300">
+            Found with id <Text>{data.id}</Text>
+          </Text>
+
+          <View className="flex items-center flex-row gap-2">
+            <Text className="text-slate-300">Reset search</Text>
+            <TouchableOpacity
+              onPress={() => {
+                setData(undefined);
+                setResult(undefined);
+              }}
+            >
+              <Ionicons name="md-reload-sharp" size={15} color="black" />
+            </TouchableOpacity>
+          </View>
+        </View>
+      ) : undefined}
+
+      {/* FOUND DATA CARD */}
+      {data && !loading ? (
+        <View className="py-1">
+          <ExtensionCard value={data} rn={props} compact={true} />
+        </View>
+      ) : undefined}
     </View>
   );
 }

--- a/screens/ScannerScreen.tsx
+++ b/screens/ScannerScreen.tsx
@@ -4,7 +4,7 @@ import RequestingCamera from "../components/miscs/RequestingCamera";
 import ExtCardSkeleton from "../components/skeleton/ExtCardSkeleton";
 import { BarCodeEvent, BarCodeScanner } from "expo-barcode-scanner";
 import { useEffect, useState } from "react";
-import { View, Text, TouchableOpacity } from "react-native";
+import { View, Text, TouchableOpacity, StatusBar } from "react-native";
 import { IData } from "../constants/data";
 import { fetchSpecificData } from "../libs/fetchData";
 import { isNumeric } from "../libs/isNumeric";
@@ -77,50 +77,64 @@ export default function ScannerScreen(props: NavigationType<"ScannerScreen">) {
   }
 
   return (
-    <View className="flex-1 px-2 py-4">
+    <View className="flex-1">
+      <StatusBar
+        barStyle="dark-content"
+        animated={true}
+        translucent={true}
+        backgroundColor="transparent"
+      />
+
       {/* BARCODE SCANNER */}
-      <View className="h-[500px] w-full items-center overflow-hidden rounded-2xl shadow-xl">
+      <View className="h-[500px] w-full items-center overflow-hidden">
         <BarCodeScanner
           onBarCodeScanned={data ? undefined : handleBarcodeScanner}
           style={{ height: 1000, width: 1000, borderRadius: 30 }}
         />
       </View>
 
-      {/* BARCODE SCANNER HELPER TEXT */}
-      <View className="py-2 items-center">
-        <Text className="text-slate-400">Scan the QR code</Text>
-      </View>
+      <View className="rounded-3xl flex-1 -mt-16 bg-white">
+        {/* BARCODE SCANNER HELPER TEXT */}
+        <View className="py-2 items-center">
+          <Text className="text-slate-400">Scan the QR code</Text>
+        </View>
 
-      {/* SKELETON */}
-      {loading ? <ExtCardSkeleton count={1} compact={true} /> : undefined}
+        {/* SKELETON */}
+        {loading ? <ExtCardSkeleton count={1} compact={true} /> : undefined}
 
-      {/* FOUND DATA TITLE AND RESET BUTTON */}
-      {data && !loading ? (
-        <View className="flex flex-row justify-between px-2 my-4">
-          <Text className="text-slate-300">
-            Found with id <Text>{data.id}</Text>
-          </Text>
+        {/* FOUND DATA TITLE AND RESET BUTTON */}
+        {data && !loading ? (
+          <View className="flex flex-row justify-between px-6 my-4">
+            <Text>
+              Found with id <Text>{data.id}</Text>
+            </Text>
 
-          <View className="flex items-center flex-row gap-2">
-            <Text className="text-slate-300">Reset search</Text>
-            <TouchableOpacity
-              onPress={() => {
-                setData(undefined);
-                setResult(undefined);
-              }}
-            >
-              <Ionicons name="md-reload-sharp" size={15} color="black" />
-            </TouchableOpacity>
+            <View className="flex items-center flex-row gap-2">
+              <Text>Reset</Text>
+              <TouchableOpacity
+                onPress={() => {
+                  setData(undefined);
+                  setResult(undefined);
+                }}
+              >
+                <Ionicons
+                  style={{ marginTop: 2 }}
+                  name="md-reload-sharp"
+                  size={15}
+                  color="black"
+                />
+              </TouchableOpacity>
+            </View>
           </View>
-        </View>
-      ) : undefined}
+        ) : undefined}
 
-      {/* FOUND DATA CARD */}
-      {data && !loading ? (
-        <View className="py-1">
-          <ExtensionCard value={data} rn={props} compact={true} />
-        </View>
-      ) : undefined}
+        {/* FOUND DATA CARD */}
+        {data && !loading ? (
+          <View className="py-1 px-2">
+            <ExtensionCard value={data} rn={props} compact={true} />
+          </View>
+        ) : undefined}
+      </View>
     </View>
   );
 }

--- a/screens/StackScreen.tsx
+++ b/screens/StackScreen.tsx
@@ -6,6 +6,7 @@ import HomeScreen from "../screens/HomeScreen";
 import AboutScreen from "./AboutScreen";
 import AboutHeaderRight from "../components/header/AboutHeaderRight";
 import * as Linking from "expo-linking";
+import ScannerScreen from "./ScannerScreen";
 
 const Stack = createNativeStackNavigator<StackList>();
 
@@ -19,6 +20,7 @@ export default function StackScreen() {
     config: {
       screens: {
         HomeScreen: "home",
+        ScannerScreen: "scan",
         AboutScreen: "about",
       },
     },
@@ -34,6 +36,7 @@ export default function StackScreen() {
       >
         <Stack.Screen name="HomeScreen" component={HomeScreen} />
         <Stack.Screen name="DetailScreen" component={DetailScreen} />
+        <Stack.Screen name="ScannerScreen" component={ScannerScreen} />
         <Stack.Screen
           name="AboutScreen"
           component={AboutScreen}

--- a/types/stack.ts
+++ b/types/stack.ts
@@ -3,5 +3,6 @@ import { IData } from "../constants/data";
 export type StackList = {
   HomeScreen: undefined;
   DetailScreen: IData;
+  ScannerScreen: undefined;
   AboutScreen: undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3142,6 +3142,14 @@ expo-asset@~8.6.1:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
+expo-barcode-scanner@~11.4.0:
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/expo-barcode-scanner/-/expo-barcode-scanner-11.4.0.tgz#d36f1cf76a7b1e48384681560a419e85d8018804"
+  integrity sha512-Q4BreQHY5U1aGF+rfqeGSzcdlayTKnSe/qTIfkXTmXFsL7bu3hMqdh5J/DL00Dfmc7C0IR8EiV75rqRrY4t0nA==
+  dependencies:
+    "@expo/config-plugins" "~5.0.0"
+    expo-image-loader "~3.2.0"
+
 expo-build-properties@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-0.3.0.tgz#807882710318a4e68fb3b4f6ae6b5882db071937"
@@ -3178,6 +3186,11 @@ expo-font@~10.2.0:
   integrity sha512-2V4EcpmhNoppaLn+lPprZVS+3bmV9hxLPKttKh2u8ghjH/oX9bv3u4JVo77SYh0EfrWO4toqVyXn8pXH8GpbIg==
   dependencies:
     fontfaceobserver "^2.1.0"
+
+expo-image-loader@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-3.2.0.tgz#d98b021660edef7243f7c5ec011b8d0545626d41"
+  integrity sha512-LU3Q2prn64/HxdToDmxgMIRXS1ZvD9Q3iCxRVTZn1fPQNNDciIQFE5okaa74Ogx20DFHs90r6WoUd7w9Af1OGQ==
 
 expo-keep-awake@~10.2.0:
   version "10.2.0"


### PR DESCRIPTION
Easily scan the QR Code to navigate into the detail extension.

This already works nicely but some needs to improve in the future:
* Better UI (Somewhat fixed in b47f413792145547ca3d649fe39edbc985943408)
* Would be nice to detect the "shake" gesture to open the scanner
* After scan should automatically go to the detail page because at this point, we have to click the card to go to the detail page (efficiency questionable).